### PR TITLE
DC-1979: removing extra spaces from customer name in reply form

### DIFF
--- a/app/uk/gov/hmrc/twowaymessageadviserfrontend/services/ReplyService.scala
+++ b/app/uk/gov/hmrc/twowaymessageadviserfrontend/services/ReplyService.scala
@@ -53,32 +53,6 @@ class ReplyService @Inject()(override val messagesApi: MessagesApi, twoWayMessag
   }
 
   /**
-    * Get the default text with inserted values to pre-populate the adviser reply message
-    */
-  def getDefaultText(maybeMetadata: Option[MessageMetadata], threadSize: Int, name: Name): String = {
-    val textVersion = getReplyTextVersion(threadSize)
-    val adviserName = getAdviserName(name)
-    getReplyInfo(maybeMetadata) match {
-      case Some(replyInfo) =>
-        s"""${Messages("reply.text.para.1",NameCase.nc(replyInfo.taxpayerName))}\n
-           |${Messages("reply.text.para.2",replyInfo.messageDate)}\n
-           |${Messages("reply.text.para.3." + textVersion)}\n
-           |${Messages("reply.text.para.4")}\n
-           |${getSignatureText(adviserName)}
-           |${Messages("reply.text.signature.2")}""".stripMargin.replace("\\'","'")
-      case None => ""
-    }
-  }
-
-  def getSignatureText(adviserName: String): String = {
-    if(adviserName != "") {
-      s"${Messages("reply.text.signature.1")}\n$adviserName"
-    } else {
-      s"${Messages("reply.text.signature.1")}"
-    }
-  }
-
-  /**
     * Get the default HTML with inserted values to pre-populate the adviser's reply
     */
   def getDefaultHtml(maybeMetadata: Option[MessageMetadata], threadSize: Int, name: Name): Html = {
@@ -108,10 +82,15 @@ class ReplyService @Inject()(override val messagesApi: MessagesApi, twoWayMessag
     (firstName + " " + lastName).trim
   }
 
+  private def getTaxpayerName(replyInfo: ReplyInfo): String = {
+    val taxpayerName = NameCase.nc(replyInfo.taxpayerName)
+    taxpayerName.trim().replaceAll("\\s+"," ")
+  }
+
   private def getMessagesHtml(replyInfo: ReplyInfo, threadSize: Int, name: Name): NodeBuffer = {
     val textVersion = getReplyTextVersion(threadSize)
     val adviserName = getAdviserName(name)
-    <p>{Messages("reply.text.para.1", NameCase.nc(replyInfo.taxpayerName))}</p>
+    <p>{Messages("reply.text.para.1", getTaxpayerName(replyInfo))}</p>
       <p>{Messages("reply.text.para.2", replyInfo.messageDate)}</p>
       <p>{Messages("reply.text.para.3." + textVersion)}</p>
       <p>{Messages("reply.text.para.4")}</p>

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,38 +6,34 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-
-    "uk.gov.hmrc"             %% "govuk-template"           % "5.3.0",
-    "uk.gov.hmrc"             %% "play-ui"                  % "7.27.0-play-25",
-    // "uk.gov.hmrc"             %% "bootstrap-play-25"        % "4.6.0",
-    "uk.gov.hmrc"             %% "bootstrap-play-25"        % "4.8.0",
-    "uk.gov.hmrc"             %% "play-reactivemongo"       % "6.2.0",
-    "uk.gov.hmrc"             %% "play-language"            % "3.4.0",
-    "uk.gov.hmrc"             %% "play-partials"            % "6.3.0"
+    "org.reactivemongo" %% "reactivemongo"      % "0.18.1",
+    "uk.gov.hmrc"       %% "govuk-template"     % "5.3.0",
+    "uk.gov.hmrc"       %% "play-ui"            % "7.40.0-play-25",
+    "uk.gov.hmrc"       %% "bootstrap-play-25"  % "4.13.0",
+    "uk.gov.hmrc"       %% "play-language"      % "3.4.0",
+    "uk.gov.hmrc"       %% "play-partials"      % "6.9.0-play-25"
   )
 
   val test = Seq(
-    "com.typesafe.play"       %% "play-test"                % current                 % "test",
-    "com.typesafe.play" %% "play-test" % current % "test",
-    "io.github.cloudify" %% "spdf" % "1.3.1" % "test",
-    "org.jsoup"               %  "jsoup"                    % "1.10.2"                % "test",
-    "org.mockito" % "mockito-core" % "2.23.4" % "test",
-    "org.pegdown"             %  "pegdown"                  % "1.6.0"                 % "test, it",
-    "org.scalatest"           %% "scalatest"                % "3.0.4"                 % "test",
-    "org.scalatest" %% "scalatest" % "3.0.5" % "test",
-    "net.codingwell" %% "scala-guice" % "4.2.2" % "test",
-
-    "uk.gov.hmrc" %% "hmrctest" % "3.2.0" % "test,it",
-
-    "com.github.tomakehurst" % "wiremock-standalone" % "2.20.0" % "test,it",
-    "io.netty" % "netty-buffer" % "4.0.56.Final"   % "test, it",
-    "io.netty" % "netty-codec-http" % "4.0.56.Final"   % "test, it",
-    "io.netty" % "netty-transport-native-epoll" % "4.0.56.Final"   % "test, it",
-    "org.asynchttpclient" % "async-http-client" % "2.0.39"   % "test, it",
-    "org.scalacheck" %% "scalacheck" % "1.14.0" % "test,it",
-    "org.scalamock" %% "scalamock-scalatest-support" % "3.6.0" % "test,it",
-    "org.scalatestplus.play"  %% "scalatestplus-play"       % "2.0.1"                 % "test, it",
-    "uk.gov.hmrc"             %% "service-integration-test" % "0.2.0"                 % "test, it"
+    "com.typesafe.play"       %% "play-test"                    % current         % "test",
+    "com.typesafe.play"       %% "play-test"                    % current         % "test",
+    "io.github.cloudify"      %% "spdf"                         % "1.3.1"         % "test",
+    "org.jsoup"               %  "jsoup"                        % "1.10.2"        % "test",
+    "org.mockito"             % "mockito-core"                  % "2.23.4"        % "test",
+    "org.pegdown"             %  "pegdown"                      % "1.6.0"         % "test, it",
+    "org.scalatest"           %% "scalatest"                    % "3.0.4"         % "test",
+    "org.scalatest"           %% "scalatest"                    % "3.0.5"         % "test",
+    "net.codingwell"          %% "scala-guice"                  % "4.2.2"       % "test",
+    "uk.gov.hmrc"             %% "hmrctest"                     % "3.9.0-play-25" % "test,it",
+    "com.github.tomakehurst"  % "wiremock-standalone"           % "2.20.0"        % "test,it",
+    "io.netty"                % "netty-buffer"                  % "4.0.56.Final"  % "test, it",
+    "io.netty"                % "netty-codec-http"              % "4.0.56.Final"  % "test, it",
+    "io.netty"                % "netty-transport-native-epoll"  % "4.0.56.Final"  % "test, it",
+    "org.asynchttpclient"     % "async-http-client"             % "2.0.39"        % "test, it",
+    "org.scalacheck"          %% "scalacheck"                   % "1.14.0"        % "test,it",
+    "org.scalamock"           %% "scalamock-scalatest-support"  % "3.6.0"         % "test,it",
+    "org.scalatestplus.play"  %% "scalatestplus-play"           % "2.0.1"         % "test, it",
+    "uk.gov.hmrc"             %% "service-integration-test"     % "0.2.0"         % "test, it"
   )
 
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,15 +4,16 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.16.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.19.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.2.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.6.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.14.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.19.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.19")
+
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.9.0")
 
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.9")
@@ -24,7 +25,11 @@ addSbtPlugin("net.ground5hark.sbt" % "sbt-concat" % "0.1.9")
 addSbtPlugin("com.typesafe.sbt" % "sbt-uglify" % "1.0.4")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.2")
+
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+
+addSbtPlugin("com.github.cb372" % "sbt-explicit-dependencies" % "0.2.9")
+
 

--- a/test/uk/gov/hmrc/twowaymessageadviserfrontend/services/ReplyServiceSpec.scala
+++ b/test/uk/gov/hmrc/twowaymessageadviserfrontend/services/ReplyServiceSpec.scala
@@ -38,6 +38,15 @@ class ReplyServiceSpec extends WordSpec with Matchers {
     "29th April 2019"
   )
 
+  private val metadataWithPaddedTaxpayerName = MessageMetadata(
+    "",
+    TaxEntity("",TaxIdWithName("",""),None),
+    "",
+    MetadataDetails(None,None,None),
+    Some(TaxpayerName(Some(" mr "),Some(" mickey    "),None,Some("  mouse  "))),
+    "29th April 2019"
+  )
+
   private val metadataWithoutTaxpayerName = MessageMetadata(
     "",
     TaxEntity("",TaxIdWithName("",""),None),
@@ -46,43 +55,6 @@ class ReplyServiceSpec extends WordSpec with Matchers {
     Some(TaxpayerName()),
     "29th April 2019"
   )
-
-  "ReplyService.getDefaultText" should {
-
-    "return auto-filled text" in {
-
-      val expectedText = """Dear Mr Mickey Mouse
-      |
-      |Thank you for your message of 29th April 2019.
-      |
-      |To recap your question, I think you're asking for help with
-      |
-      |I believe this answers your question and hope you are satisfied with the response. There's no need to send a reply. But if you think there's something important missing, just ask another question about this below.
-      |
-      |Regards
-      |Minnie Mouse
-      |HMRC digital team""".stripMargin
-      val defaultText = replyService.getDefaultText(Some(metadataWithTaxpayerName), threadSize = 1,Name(Some("Minnie"),Some("Mouse")))
-      defaultText shouldBe expectedText
-    }
-
-    "return text with default values" in {
-
-      val expectedText = """Dear Customer
-      |
-      |Thank you for your message of 29th April 2019.
-      |
-      |To recap your question, I think you're asking for help with
-      |
-      |I believe this answers your question and hope you are satisfied with the response. There's no need to send a reply. But if you think there's something important missing, just ask another question about this below.
-      |
-      |Regards
-      |HMRC digital team""".stripMargin
-      val defaultText = replyService.getDefaultText(Some(metadataWithoutTaxpayerName),threadSize = 1,Name(None,None))
-      defaultText shouldBe expectedText
-    }
-    SharedMetricRegistries.clear()
-  }
 
   "ReplyService.getDefaultHtml" should {
 
@@ -98,6 +70,9 @@ class ReplyServiceSpec extends WordSpec with Matchers {
       val defaultHtml = replyService.getDefaultHtml(Some(metadataWithTaxpayerName), threadSize = 1,Name(Some("Minnie"),Some("Mouse")))
       defaultHtml shouldBe expectedHtml
 
+      val defaultHtml2 = replyService.getDefaultHtml(Some(metadataWithPaddedTaxpayerName), threadSize = 1,Name(Some("Minnie"),Some("Mouse")))
+      defaultHtml2 shouldBe expectedHtml
+
     }
 
     "return HTML with default values" in {
@@ -112,6 +87,9 @@ class ReplyServiceSpec extends WordSpec with Matchers {
       val defaultHtml = replyService.getDefaultHtml(Some(metadataWithoutTaxpayerName),threadSize = 1,Name(None,None))
       defaultHtml shouldBe expectedHtml
     }
+
+    SharedMetricRegistries.clear()
+
   }
 
 }


### PR DESCRIPTION
also updated dependencies to comply with Bobby rules - see https://catalogue.tax.service.gov.uk/service/two-way-message-adviser-frontend